### PR TITLE
<Branch> Add page breakage before new exercise

### DIFF
--- a/prototypes_backwards.py
+++ b/prototypes_backwards.py
@@ -40,8 +40,8 @@ content = parted_head[0]
 for clone in clones:
   clone_data = part_file(open(clone, 'r').readlines(), ending)[0]
 
-  # Add header.
-  content.append('\n\problem{%s}\n' % clone.split('.')[0])
+  # Add header and page break before new exercise.
+  content.append('\n\pagebreak\n\problem{%s}\n' % clone.split('.')[0])
   # There is data before "\problem". So body of the first problem is inside parted_clone[2].
   # Fails if there is no problem. And it must fail in order to notify authors.
   content.extend(part_file(clone_data, problem)[2])


### PR DESCRIPTION
Why is it here and not in master? Because it's controversial change for lessons without large tables and is actually used for them only.

Not to be ever merged